### PR TITLE
Move to node16 for configure-aws-credentials

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ inputs.role }}
         aws-region: ${{ inputs.region }}


### PR DESCRIPTION
To remove the deprecation message in all workflow runs