### PR TITLE
POP-2767 add coldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adding a cooldown of 7 days to the dependabot config to safeguard against supply-chain attacks.
